### PR TITLE
dmicheck: Type 4 Processor Characteristics bit 9 is no longer reserved

### DIFF
--- a/src/dmi/dmicheck/dmicheck.c
+++ b/src/dmi/dmicheck/dmicheck.c
@@ -1365,7 +1365,7 @@ static void dmicheck_entry(fwts_framework *fw,
 			dmi_str_check(fw, table, addr, "Part Number", hdr, 0x22);
 			if (hdr->length < 0x28)
 				break;
-			dmi_reserved_bits_check(fw, table, addr, "Processor Characteristics", hdr, sizeof(uint16_t), 0x26, 9, 15);
+			dmi_reserved_bits_check(fw, table, addr, "Processor Characteristics", hdr, sizeof(uint16_t), 0x26, 10, 15);
 			if (hdr->length < 0x30)
 				break;
 			dmi_min_max_uint16_check(fw, table, addr, "Core Count 2", hdr, 0x2a, 0, 0xfffe);


### PR DESCRIPTION
SMBIOS 3.4.0 updates the Type 4 Processor Characteristics field
so that bit 9 is the "Arm64 SoC ID".

Update dmicheck.c to avoid flagging use of that bit as an error.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>