### PR TITLE
lib: check for fwts running inside snap, add --devmode help in error …

### DIFF
--- a/src/lib/src/fwts_acpi_tables.c
+++ b/src/lib/src/fwts_acpi_tables.c
@@ -60,6 +60,7 @@ int acpi_table_generic_init(fwts_framework *fw, char *name, fwts_acpi_table_info
 {
 	if (fwts_acpi_find_table(fw, name, 0, table) != FWTS_OK) {
 		fwts_log_error(fw, "Cannot read ACPI tables.");
+		fwts_check_root_euid(fw, true);
 		return FWTS_ERROR;
 	}
 	if (*table == NULL || (*table)->length == 0) {

--- a/src/lib/src/fwts_checkeuid.c
+++ b/src/lib/src/fwts_checkeuid.c
@@ -31,8 +31,15 @@
 int fwts_check_root_euid(fwts_framework *fw, const bool warn)
 {
 	if (geteuid() != 0) {
-		if (warn)
-			fwts_log_error(fw, "Must be run as root or sudo to be able to read system information.");
+		if (warn) {
+			if (warn)
+				fwts_log_error(fw, "Must be run as root or sudo to be able to read system information.");
+		}
+		return FWTS_ERROR;
+	}
+	/* If $SNAP environment variable set, assume it's a snap install */
+	if (getenv("SNAP") != NULL) {
+		fwts_log_error(fw, "FWTS snaps need to be installed using --devmode to be able to read system information.");
 		return FWTS_ERROR;
 	}
 	return FWTS_OK;


### PR DESCRIPTION
…message

BugLink: https://bugs.launchpad.net/bugs/2045910

Add a naïve check to see if fwts is running inside a snap by checking for the $SNAP environment variable being set. Add a --devnode help error message to help user understand why tests are failing.