### PR TITLE
lib: fwts_acpi_tables: Ensure dir_entries is initialized to NULL

### DIFF
--- a/src/lib/src/fwts_acpi_tables.c
+++ b/src/lib/src/fwts_acpi_tables.c
@@ -824,7 +824,7 @@ static int fwts_acpi_load_tables_from_file_generic(
 	const char *extension,
 	int *count)
 {
-	struct dirent **dir_entries;
+	struct dirent **dir_entries = NULL;
 	int i, n;
 
 	*count = 0;

--- a/src/lib/src/fwts_mmap.c
+++ b/src/lib/src/fwts_mmap.c
@@ -61,6 +61,10 @@ void *fwts_mmap(const off_t start, const size_t size)
 	offset = ((size_t)start) & (page_size - 1);
 	length = (size_t)size + offset;
 
+	/* check for unlikely start - offset underflows */
+	if (offset >= start)
+		return ret;
+
 	if ((fd = open("/dev/mem", O_RDONLY)) < 0)
 		return ret;
 

--- a/src/opal/mtd_info.c
+++ b/src/opal/mtd_info.c
@@ -169,7 +169,7 @@ static int mtd_info_test1(fwts_framework *fw)
 	char fdt_node_path[PATH_MAX + 1];
 	int count, i, fd;
 	ssize_t bytes = 0, bytes_read = 0;
-	struct dirent **namelist;
+	struct dirent **namelist = NULL;
 
 	fd = open(FDT_FLASH_PATH, O_RDONLY);
 	if (fd < 0) {


### PR DESCRIPTION
The dir_entries should be initialized to NULL to be extra safe when using scandir. Fix this.

Fixes: 592a526a6f49 ("lib: fwts_acpi_tables: load tables in deterministically")